### PR TITLE
Fix for dev forcats

### DIFF
--- a/R/age-categories.R
+++ b/R/age-categories.R
@@ -185,9 +185,9 @@ group_age_categories <- function(dat,
 
   if (drop_empty_overlaps) {
     # Remove any overlapping levels
-    droppings <- c(if (d) levels(we)[1] else NA,
-                   if (w) levels(mo)[1] else NA,
-                   if (m) levels(ye)[1] else NA)
+    droppings <- c(if (d) levels(we)[1] else NA_character_,
+                   if (w) levels(mo)[1] else NA_character_,
+                   if (m) levels(ye)[1] else NA_character_)
     res       <- forcats::fct_drop(res, droppings)
   }
 


### PR DESCRIPTION
`fct_drop()` now errors if `only` is not a character vector.

We are planning to submit forcats to CRAN on Jan 27.